### PR TITLE
Update rasterwriter.py

### DIFF
--- a/src/rasterwriter.py
+++ b/src/rasterwriter.py
@@ -147,7 +147,10 @@ class RasterWriter(SVGHandler):
             # TODO this is very fragile
             rx = 0
             ry = 0
-            for l in stdoutdata.splitlines():
+
+            out = stdoutdata.replace(",",".").splitlines()
+            
+            for l in out:
                 m = re.match(cls.INKSCAPE_AREA_PATTERN, l)
                 if (m):
                     rx = float(m.group(1))


### PR DESCRIPTION
In my ubuntu 14.04 box, the inkscape output was using "," instead of "," for the floats returned by stdout inside the exportRaste method. The output was, for example: "Area 232,857:90:834,286:422,857 exported to 601 x 333 pixels (90 dpi)". So raster export was throwing a Python error "TypeError: 'NoneType' object is not iterable". I solved this by replacing "," with ".", and now it works like a charm.
